### PR TITLE
Bug/closing period UI reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Remove 1s login delay
+- Ensure period is updated reactively on frontend when closed, name changed, or end date changed #389 #390
 
 ## [0.6.0] - 2022-05-09
 

--- a/packages/api/src/period/controllers.ts
+++ b/packages/api/src/period/controllers.ts
@@ -43,7 +43,6 @@ import { parseISO } from 'date-fns';
 import {
   AssignQuantifiersDryRunOutput,
   PeriodDetailsDto,
-  PeriodDto,
   PeriodStatusType,
   PeriodUpdateInput,
   VerifyQuantifierPoolSizeResponse,
@@ -117,7 +116,7 @@ export const single = async (
  */
 export const create = async (
   req: TypedRequestBody<PeriodUpdateInput>,
-  res: TypedResponse<PeriodDto>
+  res: TypedResponse<PeriodDetailsDto>
 ): Promise<void> => {
   const { name, endDate } = req.body;
   const period = await PeriodModel.create({ name, endDate });
@@ -131,7 +130,9 @@ export const create = async (
     }
   );
 
-  res.status(StatusCodes.OK).json(periodDocumentTransformer(period));
+  const periodDetailsDto = await findPeriodDetailsDto(period._id);
+
+  res.status(StatusCodes.OK).json(periodDetailsDto);
 };
 
 /**
@@ -140,7 +141,7 @@ export const create = async (
  */
 export const update = async (
   req: TypedRequestBody<PeriodUpdateInput>,
-  res: TypedResponse<PeriodDto>
+  res: TypedResponse<PeriodDetailsDto>
 ): Promise<void> => {
   const period = await PeriodModel.findById(req.params.periodId);
   if (!period) throw new NotFoundError('Period');
@@ -199,7 +200,7 @@ export const update = async (
  */
 export const close = async (
   req: Request,
-  res: TypedResponse<PeriodDto>
+  res: TypedResponse<PeriodDetailsDto>
 ): Promise<void> => {
   const period = await PeriodModel.findById(req.params.periodId);
   if (!period) throw new NotFoundError('Period');

--- a/packages/api/src/period/transformers.ts
+++ b/packages/api/src/period/transformers.ts
@@ -5,10 +5,12 @@ import {
   PeriodDetailsReceiver,
   PeriodDetailsReceiverDto,
   PeriodDocument,
-  PeriodDto,
+  PeriodDetailsDto,
 } from './types';
 
-const periodDocumentToDto = (periodDocument: PeriodDocument): PeriodDto => {
+const periodDocumentToDto = (
+  periodDocument: PeriodDocument
+): PeriodDetailsDto => {
   const { _id, name, status, endDate, createdAt, updatedAt } = periodDocument;
   return {
     _id,
@@ -22,7 +24,7 @@ const periodDocumentToDto = (periodDocument: PeriodDocument): PeriodDto => {
 
 export const periodDocumentListTransformer = (
   periodDocuments: PeriodDocument[] | undefined
-): PeriodDto[] => {
+): PeriodDetailsDto[] => {
   if (periodDocuments && Array.isArray(periodDocuments)) {
     return periodDocuments.map((periodDocument) =>
       periodDocumentToDto(periodDocument)
@@ -33,7 +35,7 @@ export const periodDocumentListTransformer = (
 
 export const periodDocumentTransformer = (
   periodDocument: PeriodDocument
-): PeriodDto => {
+): PeriodDetailsDto => {
   return periodDocumentToDto(periodDocument);
 };
 

--- a/packages/api/src/period/types.ts
+++ b/packages/api/src/period/types.ts
@@ -28,15 +28,6 @@ export interface PeriodDocument extends Period, mongoose.Document {
   $__: any;
 }
 
-export interface PeriodDto {
-  _id: string;
-  name: string;
-  status: PeriodStatusType;
-  endDate: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
 export interface PeriodDetailsReceiver {
   _id: Types.ObjectId;
   praiseCount: number;
@@ -65,7 +56,13 @@ export interface PeriodDetailsQuantifierDto {
   praiseCount: number;
 }
 
-export interface PeriodDetailsDto extends PeriodDto {
+export interface PeriodDetailsDto {
+  _id: string;
+  name: string;
+  status: PeriodStatusType;
+  endDate: string;
+  createdAt: string;
+  updatedAt: string;
   quantifiers?: PeriodDetailsQuantifierDto[];
   receivers?: PeriodDetailsReceiverDto[];
   settings?: PeriodSettingDto[];

--- a/packages/frontend/src/model/periods.ts
+++ b/packages/frontend/src/model/periods.ts
@@ -4,7 +4,6 @@ import { periodQuantifierPraiseListKey } from '@/utils/periods';
 import {
   PeriodCreateInput,
   PeriodDetailsDto,
-  PeriodDto,
   PeriodStatusType,
   PeriodUpdateInput,
 } from 'api/dist/period/types';
@@ -333,7 +332,7 @@ export const useClosePeriod = (): useClosePeriodReturn => {
         );
 
         if (isResponseOk(response)) {
-          const period = response.data as PeriodDto;
+          const period = response.data as PeriodDetailsDto;
 
           if (period) {
             set(SinglePeriod(period._id), period);
@@ -537,7 +536,7 @@ export const usePeriodReceiverPraiseQuery = (
 };
 
 type useExportPraiseReturn = {
-  exportPraise: (period: PeriodDto) => Promise<Blob | undefined>;
+  exportPraise: (period: PeriodDetailsDto) => Promise<Blob | undefined>;
 };
 /**
  * Hook that exports all praise in a period as csv data.
@@ -547,7 +546,7 @@ export const useExportPraise = (): useExportPraiseReturn => {
 
   const exportPraise = useRecoilCallback(
     ({ snapshot }) =>
-      async (period: PeriodDto): Promise<Blob | undefined> => {
+      async (period: PeriodDetailsDto): Promise<Blob | undefined> => {
         if (!period || !allPeriods) return undefined;
         const response = await ApiQuery(
           snapshot.getPromise(

--- a/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
+++ b/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
@@ -17,7 +17,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import React, { Suspense } from 'react';
 import {
-  useHistory,
   useParams,
   useRouteMatch,
   Switch,
@@ -66,9 +65,7 @@ const PeriodDetailPage = (): JSX.Element | null => {
   const period = useRecoilValue(SinglePeriod(periodId));
   const isAdmin = useRecoilValue(HasRole(ROLE_ADMIN));
   const { path, url } = useRouteMatch();
-  const { location } = useHistory();
-
-  useSinglePeriodQuery(periodId, location.key);
+  useSinglePeriodQuery(periodId);
 
   if (!period || !period.receivers) return null;
 

--- a/packages/frontend/src/pages/Periods/components/Table.tsx
+++ b/packages/frontend/src/pages/Periods/components/Table.tsx
@@ -1,7 +1,7 @@
 import { AllPeriods } from '@/model/periods';
 import { formatIsoDateUTC } from '@/utils/date';
 import { classNames } from '@/utils/index';
-import { PeriodDto } from 'api/dist/period/types';
+import { PeriodDetailsDto } from 'api/dist/period/types';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { TableOptions, useTable } from 'react-table';
@@ -98,7 +98,7 @@ const PeriodsTable = (): JSX.Element => {
               )}
               id="" //TODO set id
               {...row.getRowProps()}
-              onClick={handleClick((row.original as PeriodDto)._id)}
+              onClick={handleClick((row.original as PeriodDetailsDto)._id)}
             >
               {row.cells.map((cell) => {
                 // eslint-disable-next-line react/jsx-key

--- a/packages/frontend/src/utils/periods.ts
+++ b/packages/frontend/src/utils/periods.ts
@@ -1,15 +1,14 @@
 import { QuantifierReceiverData } from '@/model/periods';
 import {
-  PeriodDetailsDto,
   PeriodDetailsQuantifierDto,
-  PeriodDto,
+  PeriodDetailsDto,
   PeriodStatusType,
 } from 'api/dist/period/types';
 import { compareDesc } from 'date-fns';
 
 export const getActivePeriod = (
-  allPeriods: PeriodDto[]
-): PeriodDto | undefined => {
+  allPeriods: PeriodDetailsDto[]
+): PeriodDetailsDto | undefined => {
   const today = new Date();
   for (const period of allPeriods) {
     if (compareDesc(today, new Date(period.endDate)) >= 0) return period;
@@ -18,9 +17,9 @@ export const getActivePeriod = (
 };
 
 export const getPreviousPeriod = (
-  allPeriods: PeriodDto[],
-  period: PeriodDto
-): PeriodDto | undefined => {
+  allPeriods: PeriodDetailsDto[],
+  period: PeriodDetailsDto
+): PeriodDetailsDto | undefined => {
   const endDate = new Date(period.endDate);
   for (let i = 0; i < allPeriods.length; i++) {
     if (compareDesc(endDate, new Date(allPeriods[i].endDate)) < 0)


### PR DESCRIPTION
Resolves #389 
Resolves #390 

- Fix UI reactivity when single period is updated - on close period and update period name
- in `useSinglePeriodQuery` `fetchPeriod` is not called on period change anymore, only if periodId is changed