### PR TITLE
Fix: Prevent infinite fetching of period data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Remove 1s login delay
 - Ensure period is updated reactively on frontend when closed, name changed, or end date changed #389 #390
+- Fetch period data on period detail page only once
 
 ## [0.6.0] - 2022-05-09
 

--- a/packages/frontend/src/model/periods.ts
+++ b/packages/frontend/src/model/periods.ts
@@ -88,17 +88,18 @@ export const AllPeriods = selector({
  * Hook that fetches details for a single period from the API.
  */
 export const useSinglePeriodQuery = (periodId: string): void => {
-  const apiAuthClient = makeApiAuthClient();
   const setPeriod = useSetRecoilState(SinglePeriod(periodId));
 
   useEffect(() => {
-    const fetchPeriod = async (): Promise<void> => {
+    const fetchPeriod = async (periodId): Promise<void> => {
+      const apiAuthClient = makeApiAuthClient();
+      console.log('periodId', periodId);
       const response = await apiAuthClient.get(`/periods/${periodId}`);
       setPeriod(response.data);
     };
 
-    void fetchPeriod();
-  }, [periodId, setPeriod, apiAuthClient]);
+    void fetchPeriod(periodId);
+  }, [periodId, setPeriod]);
 };
 
 /**

--- a/packages/frontend/src/model/periods.ts
+++ b/packages/frontend/src/model/periods.ts
@@ -93,7 +93,6 @@ export const useSinglePeriodQuery = (periodId: string): void => {
   useEffect(() => {
     const fetchPeriod = async (periodId): Promise<void> => {
       const apiAuthClient = makeApiAuthClient();
-      console.log('periodId', periodId);
       const response = await apiAuthClient.get(`/periods/${periodId}`);
       setPeriod(response.data);
     };


### PR DESCRIPTION
Fixes bug introduced in #403 where `useSinglePeriodQuery` would infinitely continue fetching a single period.