### PR TITLE
Revert removal of NAME setting

### DIFF
--- a/packages/api/src/database/migrations/11_settings_revert_drop_app_name.ts
+++ b/packages/api/src/database/migrations/11_settings_revert_drop_app_name.ts
@@ -1,0 +1,25 @@
+import { SettingGroup } from '@settings/types';
+import { SettingsModel } from '@settings/entities';
+
+const deleteSettings = [
+  {
+    key: 'NAME',
+    label: 'App Name',
+    description: null,
+    group: SettingGroup.APPLICATION,
+    value: 'Praise',
+    type: 'String',
+  },
+];
+
+const up = async (): Promise<void> => {
+  await SettingsModel.insertMany(deleteSettings);
+};
+
+const down = async (): Promise<void> => {
+  const deleteSettingKeys = deleteSettings.map((s) => s.key);
+
+  await SettingsModel.deleteMany({ key: { $in: deleteSettingKeys } });
+};
+
+export { up, down };

--- a/packages/api/src/tests/setup.ts
+++ b/packages/api/src/tests/setup.ts
@@ -12,7 +12,7 @@ const mochaHooks = async (): Promise<Mocha.RootHookObject> => {
   return Promise.resolve({
     async beforeAll(this: TestContext): Promise<void> {
       // extend timeout to allow for long database migrations / application setup
-      this.timeout(20000);
+      this.timeout(30000);
 
       this.app = await setup();
       logger.info('Running api tests:\n\n');

--- a/packages/frontend/src/layouts/AuthenticatedLayout.tsx
+++ b/packages/frontend/src/layouts/AuthenticatedLayout.tsx
@@ -103,9 +103,12 @@ const AuthenticatedLayout = (): JSX.Element | null => {
               aria-hidden="true"
             />
           </button>
-          <div className="w-full flex justify-center">
-            <h1 className="font-lg">{siteNameSetting?.value}</h1>
-          </div>
+
+          {siteNameSetting && (
+            <div className="flex-grow flex justify-center">
+              <h1 className="font-lg">{siteNameSetting.value}</h1>
+            </div>
+          )}
         </div>
         <main className="flex-1 flex justify-center px-4 py-4">
           <div className="block max-w-5xl w-full">


### PR DESCRIPTION
I realized the NAME setting is displayed in the toolbar in small viewports. This setting was removed in #399 

This PR adds another migration to revert the previous one that removed the NAME setting.