### PR TITLE
v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Normalize format of praise reason, converting usernames and channel names into their human-readable text
-- Hightlight active page in Navbar, update page routes to nest under top-level routes
-- Praise dates now displayed in a "relative" format, with the absolute format displayed in a tooltip
-- Display calculated score of praise marked as duplicate instead of disabled slider on Quantify page #378
 
 ### Fixed
+
+## [0.7.0] - 2022-05-31
+
+### Added
+
+- Group setting groups to improve settings UI #131 #333 #399
+- Normalize format of praise reason, converting usernames and channel names into their human-readable text #156 #397
+- Hightlight active page in Navbar, update page routes to nest under top-level routes #244 #396
+- Praise dates now displayed in a "relative" format, with the absolute format displayed in a tooltip #249 #404
+- Display calculated score of praise marked as duplicate instead of disabled slider on Quantify page #378 #407
+- Added FAQ page #219 #372
+- Removed docs package, move documentation to https://givepraise.xyz/docs
+
+### Fixed
+
 - Remove 1s login delay
 - Ensure period is updated reactively on frontend when closed, name changed, or end date changed #389 #390
-- Immediately reflect authorization changes after modifying your own user's roles
-- Ensure'Assign Quantifiers' dialog is updated reactively when quantifier pool changes #388
+- Immediately reflect authorization changes after modifying your own user's roles #313
+- Ensure'Assign Quantifiers' dialog is updated reactively when quantifier pool changes #388 #408
 - Ensure period settings created before migration `07_settings_add_group` can be updated
-- Prevent users from marking a praise as duplicate, if it is already the original of another praise marked duplicate
+- Prevent users from marking a praise as duplicate, if it is already the original of another praise marked duplicate #394 #406
 - Fetch period data on period detail page only once
+- Prevent error notice when non-admin visits PeriodDetailPage #425
+- Upgraded to Create React App 5.0.1 and Tailwind 3 #416
+- Fixed bug affecting marking of duplicates #335 #389 #393
 
 ## [0.6.0] - 2022-05-09
 
 ### Added
+
 - Add giver and receiver id to exported praise csv #364
 - Increased precision in calculation of duplicate praise score, from 0 to 2 decimals #342
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praise",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "GPL-3.0-or-later",
   "description": "Praise community contributions to build a culture of giving and gratitude.",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "GPL-3.0-or-later",
   "description": "The Praise REST API running on Node/Express, using MongoDB for storage.",
   "type": "commonjs",

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "GPL-3.0-or-later",
   "description": "The Praise Discord bot is the main way for users to interact with the Praise system.",
   "dependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "GPL-3.0-or-later",
   "description": "The Praise dashboard built on React/Recoil/Tailwind CSS.",
   "private": true,

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "GPL-3.0-or-later",
   "description": "The Prasie data is stored in a MongoDb database."
 }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "GPL-3.0-or-later",
   "type": "commonjs",
   "description": "Praise ENV setup scripts.",


### PR DESCRIPTION
### Added

- Group setting groups to improve settings UI #131 #333 #399
- Normalize format of praise reason, converting usernames and channel names into their human-readable text #156 #397
- Hightlight active page in Navbar, update page routes to nest under top-level routes #244 #396
- Praise dates now displayed in a "relative" format, with the absolute format displayed in a tooltip #249 #404
- Display calculated score of praise marked as duplicate instead of disabled slider on Quantify page #378 #407
- Added FAQ page #219 #372
- Removed docs package, move documentation to https://givepraise.xyz/docs

### Fixed

- Remove 1s login delay
- Ensure period is updated reactively on frontend when closed, name changed, or end date changed #389 #390
- Immediately reflect authorization changes after modifying your own user's roles #313
- Ensure'Assign Quantifiers' dialog is updated reactively when quantifier pool changes #388 #408
- Ensure period settings created before migration `07_settings_add_group` can be updated
- Prevent users from marking a praise as duplicate, if it is already the original of another praise marked duplicate #394 #406
- Fetch period data on period detail page only once
- Prevent error notice when non-admin visits PeriodDetailPage #425
- Upgraded to Create React App 5.0.1 and Tailwind 3 #416
- Fixed bug affecting marking of duplicates #335 #389 #393