### PR TITLE
Fix/quantify slider displaying praise score

### DIFF
--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/PraiseRow.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/PraiseRow.tsx
@@ -3,10 +3,8 @@ import Notice from '@/components/Notice';
 import Praise from '@/components/praise/Praise';
 import { ActiveUserId } from '@/model/auth';
 import {
-  dismissed,
-  duplicate,
-  quantification,
-  shortDuplicatePraiseId,
+  findPraiseQuantification,
+  shortenDuplicatePraiseId,
 } from '@/utils/praise';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -37,11 +35,11 @@ const PraiseRow = ({
   const userId = useRecoilValue(ActiveUserId);
   if (!userId) return null;
 
-  const quantificationData = quantification(praise, userId);
-  if (!quantificationData) return null;
+  const quantification = findPraiseQuantification(praise, userId);
+  if (!quantification) return null;
 
-  const isDismissed = dismissed(praise, userId);
-  const isDuplicate = duplicate(praise, userId);
+  const dismissed = quantification.dismissed;
+  const duplicate = !!quantification.duplicatePraise;
 
   return (
     <tr className="group">
@@ -60,23 +58,23 @@ const PraiseRow = ({
           showReceiver={false}
           periodId={periodId}
           usePseudonyms={usePseudonyms}
-          dismissed={isDismissed}
-          shortDuplicatePraiseId={shortDuplicatePraiseId(praise, userId)}
+          dismissed={dismissed}
+          shortDuplicatePraiseId={shortenDuplicatePraiseId(praise, userId)}
         />
       </td>
       <td>
-        {isDuplicate ? (
+        {duplicate ? (
           <Notice type="info" className="w-40 py-2">
             <>
               Duplicate score: <br />
-              {quantificationData.scoreRealized}
+              {quantification.scoreRealized}
             </>
           </Notice>
         ) : (
           <QuantifySlider
             allowedScores={allowedValues}
-            score={quantificationData.scoreRealized}
-            disabled={isDismissed || isDuplicate}
+            score={quantification.scoreRealized}
+            disabled={dismissed || duplicate}
             onChange={onSetScore}
           />
         )}
@@ -85,7 +83,7 @@ const PraiseRow = ({
         <div className="w-3">
           <button
             className="hidden group-hover:block text-gray-400 hover:text-gray-500 cursor-pointer"
-            disabled={isDuplicate}
+            disabled={duplicate}
             onClick={onDuplicateClick}
           >
             <FontAwesomeIcon icon={faCopy} size="1x" />

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/PraiseRow.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/PraiseRow.tsx
@@ -1,0 +1,99 @@
+import { PraiseDto } from 'api/dist/praise/types';
+import Notice from '@/components/Notice';
+import Praise from '@/components/praise/Praise';
+import { ActiveUserId } from '@/model/auth';
+import {
+  dismissed,
+  duplicate,
+  quantification,
+  shortDuplicatePraiseId,
+} from '@/utils/praise';
+import { faCopy } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useRecoilValue } from 'recoil';
+import QuantifySlider from './QuantifySlider';
+
+interface Props {
+  praise: PraiseDto;
+  periodId: string;
+  usePseudonyms: boolean;
+  allowedValues: number[];
+  checked?: boolean;
+  onToggleCheck();
+  onSetScore(newScore: number);
+  onDuplicateClick();
+}
+
+const PraiseRow = ({
+  praise,
+  periodId,
+  usePseudonyms,
+  allowedValues,
+  checked = false,
+  onToggleCheck,
+  onSetScore,
+  onDuplicateClick,
+}: Props): JSX.Element | null => {
+  const userId = useRecoilValue(ActiveUserId);
+  if (!userId) return null;
+
+  const quantificationData = quantification(praise, userId);
+  if (!quantificationData) return null;
+
+  const isDismissed = dismissed(praise, userId);
+  const isDuplicate = duplicate(praise, userId);
+
+  return (
+    <tr className="group">
+      <td>
+        <input
+          type="checkbox"
+          className="mr-4 text-xl w-5 h-5"
+          checked={checked}
+          onChange={onToggleCheck}
+        />
+      </td>
+      <td>
+        <Praise
+          praise={praise}
+          showIdPrefix={true}
+          showReceiver={false}
+          periodId={periodId}
+          usePseudonyms={usePseudonyms}
+          dismissed={isDismissed}
+          shortDuplicatePraiseId={shortDuplicatePraiseId(praise, userId)}
+        />
+      </td>
+      <td>
+        {isDuplicate ? (
+          <Notice type="info" className="w-40 py-2">
+            <>
+              Duplicate score: <br />
+              {quantificationData.scoreRealized}
+            </>
+          </Notice>
+        ) : (
+          <QuantifySlider
+            allowedScores={allowedValues}
+            score={quantificationData.scoreRealized}
+            disabled={isDismissed || isDuplicate}
+            onChange={onSetScore}
+          />
+        )}
+      </td>
+      <td>
+        <div className="w-3">
+          <button
+            className="hidden group-hover:block text-gray-400 hover:text-gray-500 cursor-pointer"
+            disabled={isDuplicate}
+            onClick={onDuplicateClick}
+          >
+            <FontAwesomeIcon icon={faCopy} size="1x" />
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+};
+
+export default PraiseRow;

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyPraiseRow.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyPraiseRow.tsx
@@ -22,7 +22,7 @@ interface Props {
   onDuplicateClick();
 }
 
-const PraiseRow = ({
+const QuantifyPraiseRow = ({
   praise,
   periodId,
   usePseudonyms,
@@ -94,4 +94,4 @@ const PraiseRow = ({
   );
 };
 
-export default PraiseRow;
+export default QuantifyPraiseRow;

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
@@ -4,7 +4,12 @@ import { PeriodQuantifierReceiverPraise } from '@/model/periods';
 import { useQuantifyPraise } from '@/model/praise';
 import { usePeriodSettingValueRealized } from '@/model/periodsettings';
 import Praise from '@/components/praise/Praise';
-import { dismissed, duplicate, shortDuplicatePraiseId } from '@/utils/praise';
+import {
+  dismissed,
+  duplicate,
+  quantification,
+  shortDuplicatePraiseId,
+} from '@/utils/praise';
 import { ActiveUserId } from '@/model/auth';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -170,13 +175,13 @@ const QuantifyTable = ({ periodId, receiverId }: Props): JSX.Element | null => {
                         <Notice type="info" className="w-40 py-2">
                           <>
                             Duplicate score: <br />
-                            {praise.scoreRealized}
+                            {quantification(praise, userId)?.scoreRealized}
                           </>
                         </Notice>
                       ) : (
                         <QuantifySlider
                           allowedScores={allowedValues}
-                          score={praise.scoreRealized}
+                          score={quantification(praise, userId)?.scoreRealized}
                           disabled={
                             dismissed(praise, userId) ||
                             duplicate(praise, userId)

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
@@ -1,18 +1,7 @@
-import Notice from '@/components/Notice';
 import { PraiseDto } from 'api/dist/praise/types';
 import { PeriodQuantifierReceiverPraise } from '@/model/periods';
 import { useQuantifyPraise } from '@/model/praise';
 import { usePeriodSettingValueRealized } from '@/model/periodsettings';
-import Praise from '@/components/praise/Praise';
-import {
-  dismissed,
-  duplicate,
-  quantification,
-  shortDuplicatePraiseId,
-} from '@/utils/praise';
-import { ActiveUserId } from '@/model/auth';
-import { faCopy } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import getWeek from 'date-fns/getWeek';
 import parseISO from 'date-fns/parseISO';
 import { groupBy, sortBy } from 'lodash';
@@ -21,10 +10,10 @@ import { useRecoilValue } from 'recoil';
 import { QuantifyBackNextLink } from './BackNextLink';
 import DismissDialog from './DismissDialog';
 import DuplicateDialog from './DuplicateDialog';
-import QuantifySlider from './QuantifySlider';
 import DuplicateSearchDialog from './DuplicateSearchDialog';
 import MarkDuplicateButton from './MarkDuplicateButton';
 import MarkDismissedButton from './MarkDismissedButton';
+import PraiseRow from './PraiseRow';
 
 interface Props {
   periodId: string;
@@ -33,7 +22,6 @@ interface Props {
 }
 
 const QuantifyTable = ({ periodId, receiverId }: Props): JSX.Element | null => {
-  const userId = useRecoilValue(ActiveUserId);
   const data = useRecoilValue(
     PeriodQuantifierReceiverPraise({ periodId, receiverId })
   );
@@ -58,7 +46,6 @@ const QuantifyTable = ({ periodId, receiverId }: Props): JSX.Element | null => {
   ) as number[];
 
   if (!data) return null;
-  if (!userId) return null;
 
   const handleDismiss = (): void => {
     if (selectedPraises.length > 0) {
@@ -146,67 +133,21 @@ const QuantifyTable = ({ periodId, receiverId }: Props): JSX.Element | null => {
                   </tr>
                 )}
 
-                {weeklyData[weekKey].map((praise, index) => (
-                  <tr className="group" key={index}>
-                    <td>
-                      <input
-                        type="checkbox"
-                        className="mr-4 text-xl w-5 h-5"
-                        checked={isChecked(praise)}
-                        onChange={(): void => handleToggleCheckbox(praise)}
-                      />
-                    </td>
-                    <td>
-                      <Praise
-                        praise={praise}
-                        showIdPrefix={true}
-                        showReceiver={false}
-                        periodId={periodId}
-                        usePseudonyms={usePseudonyms}
-                        dismissed={dismissed(praise, userId)}
-                        shortDuplicatePraiseId={shortDuplicatePraiseId(
-                          praise,
-                          userId
-                        )}
-                      />
-                    </td>
-                    <td>
-                      {duplicate(praise, userId) ? (
-                        <Notice type="info" className="w-40 py-2">
-                          <>
-                            Duplicate score: <br />
-                            {quantification(praise, userId)?.scoreRealized}
-                          </>
-                        </Notice>
-                      ) : (
-                        <QuantifySlider
-                          allowedScores={allowedValues}
-                          score={quantification(praise, userId)?.scoreRealized}
-                          disabled={
-                            dismissed(praise, userId) ||
-                            duplicate(praise, userId)
-                          }
-                          onChange={(newScore): void =>
-                            handleSetScore(praise, newScore)
-                          }
-                        />
-                      )}
-                    </td>
-                    <td>
-                      <div className="w-3">
-                        <button
-                          className="hidden group-hover:block text-gray-400 hover:text-gray-500 cursor-pointer"
-                          disabled={duplicate(praise, userId)}
-                          onClick={(): void => {
-                            setDuplicateSearchDialogPraise(praise);
-                            setIsDuplicateSearchDialogOpen(true);
-                          }}
-                        >
-                          <FontAwesomeIcon icon={faCopy} size="1x" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
+                {weeklyData[weekKey].map((praise) => (
+                  <PraiseRow
+                    praise={praise}
+                    key={praise._id}
+                    periodId={periodId}
+                    usePseudonyms={usePseudonyms}
+                    allowedValues={allowedValues}
+                    checked={isChecked(praise)}
+                    onToggleCheck={(): void => handleToggleCheckbox(praise)}
+                    onSetScore={(score): void => handleSetScore(praise, score)}
+                    onDuplicateClick={(): void => {
+                      setDuplicateSearchDialogPraise(praise);
+                      setIsDuplicateSearchDialogOpen(true);
+                    }}
+                  />
                 ))}
               </React.Fragment>
             ))}

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
@@ -13,7 +13,7 @@ import DuplicateDialog from './DuplicateDialog';
 import DuplicateSearchDialog from './DuplicateSearchDialog';
 import MarkDuplicateButton from './MarkDuplicateButton';
 import MarkDismissedButton from './MarkDismissedButton';
-import PraiseRow from './PraiseRow';
+import QuantifyPraiseRow from './QuantifyPraiseRow';
 
 interface Props {
   periodId: string;
@@ -134,9 +134,9 @@ const QuantifyTable = ({ periodId, receiverId }: Props): JSX.Element | null => {
                 )}
 
                 {weeklyData[weekKey].map((praise) => (
-                  <PraiseRow
-                    praise={praise}
+                  <QuantifyPraiseRow
                     key={praise._id}
+                    praise={praise}
                     periodId={periodId}
                     usePseudonyms={usePseudonyms}
                     allowedValues={allowedValues}

--- a/packages/frontend/src/utils/praise.ts
+++ b/packages/frontend/src/utils/praise.ts
@@ -1,26 +1,16 @@
 import { PraiseDto, QuantificationDto } from 'api/dist/praise/types';
 
-export const quantification = (
+export const findPraiseQuantification = (
   praise: PraiseDto,
   userId: string
 ): QuantificationDto | undefined => {
   return praise.quantifications.find((q) => q.quantifier === userId);
 };
 
-export const dismissed = (praise: PraiseDto, userId: string): boolean => {
-  const q = quantification(praise, userId);
-  return q ? !!q.dismissed : false;
-};
-
-export const duplicate = (praise: PraiseDto, userId: string): boolean => {
-  const q = quantification(praise, userId);
-  return q ? (q.duplicatePraise ? true : false) : false;
-};
-
-export const shortDuplicatePraiseId = (
+export const shortenDuplicatePraiseId = (
   praise: PraiseDto,
   userId: string
 ): string => {
-  const q = quantification(praise, userId);
+  const q = findPraiseQuantification(praise, userId);
   return q && q.duplicatePraise ? q.duplicatePraise?.slice(-4) : '';
 };


### PR DESCRIPTION
Resolves #444 

**Overview**
- Fix bug where praise.scoreRealized was displayed on frontend as selected value in QuantifySlider and duplicate score
- Refactoring of QuantifyTable component for clarity:
  - extract quantify praise row logic into it's own component: QuantifyPraiseRow
  - remove praise helper utils `dismissed` and `duplicate` -- move into QuantifyPraiseRow component