### PR TITLE
Feat/developer docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,3 +205,6 @@ This project uses JavaScript and the nodeJS environment. For setting up this env
  |- frontend
 
 ```
+
+## Review Developer Documentation
+Additional developer documentation is included in [DEVELOPMENT.md](./DEVELOPMENT.md)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,11 +2,13 @@
 
 ### Manually Backup and Restore Database
 
+Replace DB_ROOT_USER, DB_ROOT_PASSWORD, and BACKUP_DATE in the following commands:
+
 **Backup**
-docker exec -i mongodb-praise /usr/bin/mongodump --authenticationDatabase admin --archive -u DB_ROOT_USER -p DB_ROOT_PASSWORD --db praise_db > database-backup-$(date -I).db
+docker exec -i mongodb-praise /usr/bin/mongodump --authenticationDatabase admin --archive -u DB_ROOT_USER -p DB_ROOT_PASSWORD --db praise_db > database-backup-$(date -I).archive
 
 
 **Restore**
 ```
-docker exec -i mongodb-praise sh -c 'mongorestore --authenticationDatabase admin -u DB_ROOT_USER -p DB_ROOT_PASSWORD --db praise_db --archive' < database-backup-$(date -I).db
+docker exec -i mongodb-praise sh -c 'mongorestore --authenticationDatabase admin -u DB_ROOT_USER -p DB_ROOT_PASSWORD --db praise_db --archive' < database-backup-BACKUP_DATE.archive
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,12 @@
+# Development Docs
+
+### Manually Backup and Restore Database
+
+**Backup**
+docker exec -i mongodb-praise /usr/bin/mongodump --authenticationDatabase admin --archive -u DB_ROOT_USER -p DB_ROOT_PASSWORD --db praise_db > database-backup-$(date -I).db
+
+
+**Restore**
+```
+docker exec -i mongodb-praise sh -c 'mongorestore --authenticationDatabase admin -u DB_ROOT_USER -p DB_ROOT_PASSWORD --db praise_db --archive' < database-backup-$(date -I).db
+```


### PR DESCRIPTION
**Overview**
- add DEVELOPMENT.md  for outlining developer docs
- note commands to manually backup / restore production db in developer docs.

I don't have a strong preference on *where* these developer-specific docs go, but I'd like to keep them somewhere we can all refer back to easily.