### PR TITLE
v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+## [0.8.0] - 2022-06-06
+
+### Added
+
 - Convert the Quantifier Pool screen to a User Admin screen #320 #395
 
 ### Fixed
 
+- Removed migration unable to fetch info from Discord threads #445
+- Quantify slider displaying praise score #444 #443
 - Clicking a link within a Praise reason should _only_ trigger opening the link #427 #437
 
 ## [0.7.0] - 2022-05-31

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praise",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "GPL-3.0-or-later",
   "description": "Praise community contributions to build a culture of giving and gratitude.",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "GPL-3.0-or-later",
   "description": "The Praise REST API running on Node/Express, using MongoDB for storage.",
   "type": "commonjs",

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "GPL-3.0-or-later",
   "description": "The Praise Discord bot is the main way for users to interact with the Praise system.",
   "dependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "GPL-3.0-or-later",
   "description": "The Praise dashboard built on React/Recoil/Tailwind CSS.",
   "private": true,

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "GPL-3.0-or-later",
   "description": "The Prasie data is stored in a MongoDb database."
 }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "GPL-3.0-or-later",
   "type": "commonjs",
   "description": "Praise ENV setup scripts.",


### PR DESCRIPTION
### Added

- Convert the Quantifier Pool screen to a User Admin screen #320 #395

### Fixed

- Removed migration unable to fetch info from Discord threads #445
- Quantify slider displaying praise score #444 #443
- Clicking a link within a Praise reason should _only_ trigger opening the link #427 #437