### PR TITLE
fix: prevent QuantifyTable from overflowing parent content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve dapp responsiviness #190 #356
 - Opening dialog to mark praise as duplicate should place focus on input #80
+- Prevent Quantify Table from overflowing content area #458
 
 ## [0.8.0] - 2022-06-06
 

--- a/packages/frontend/src/layouts/AuthenticatedLayout.tsx
+++ b/packages/frontend/src/layouts/AuthenticatedLayout.tsx
@@ -90,7 +90,7 @@ const AuthenticatedLayout = (): JSX.Element | null => {
       </div>
 
       <div className="md:pl-64 flex flex-col flex-1">
-        <div className="sticky top-0 z-10 md:hidden py-1 px-1 bg-gray-50 dark:bg-slate-900 border-b shadow-sm flex justify-start items-center w-full">
+        <div className="sticky h-14 top-0 z-10 md:hidden py-1 px-1 bg-gray-50 dark:bg-slate-900 border-b shadow-sm flex justify-start items-center w-full">
           <button
             type="button"
             className="-ml-0.5 -mt-0.5 h-12 w-12 inline-flex items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
@@ -108,8 +108,8 @@ const QuantifyTable = ({ periodId, receiverId }: Props): JSX.Element | null => {
   };
 
   return (
-    <div className=" h-full">
-      <div className="p-5 relative space-x-6 bg-gray-200 dark:bg-slate-700 z-10 w-full rounded-t border-t border-l border-r sticky top-0">
+    <div>
+      <div className="p-5 space-x-6 bg-gray-200 dark:bg-slate-700 z-10 w-full rounded-t border-t border-l border-r sticky top-0">
         <MarkDismissedButton
           disabled={selectedPraises.length < 1}
           onClick={(): void => setIsDismissDialogOpen(true)}

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
@@ -109,7 +109,7 @@ const QuantifyTable = ({ periodId, receiverId }: Props): JSX.Element | null => {
 
   return (
     <div>
-      <div className="p-5 space-x-6 bg-gray-200 dark:bg-slate-700 z-10 w-full rounded-t border-t border-l border-r sticky top-0">
+      <div className="p-5 space-x-6 bg-gray-200 dark:bg-slate-700 z-10 w-full rounded-t border-t border-l border-r sticky top-14 md:top-0">
         <MarkDismissedButton
           disabled={selectedPraises.length < 1}
           onClick={(): void => setIsDismissDialogOpen(true)}


### PR DESCRIPTION
**Overview**
- Resolves #458 
- Prevent quantify toolbar from overlapping header in small viewports