### PR TITLE
v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Admins can replace an actively assigned quantifier with another
 
+### Fixed
+
+## [0.10.0] - 2022-07-01
+
+### Added
+
+- Admins can replace an actively assigned quantifier with another #432 #503
 - Additional test coverage for api
+- Freetext filter of quantification list #422
+- Quantify multiple items at the same time #499
 
 ### Fixed
 
 - Seeder generates periods and praise in the past, not future
 - Remove check that was throwing an error when not all quantifiers were assigned praise and `PRAISE_QUANTIFIERS_ASSIGN_ALL` was enabled #492 #498
+- Codebase cleanup, documentation and refactor #509
 
 ## [0.9.0] - 2022-06-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praise",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "GPL-3.0-or-later",
   "description": "Praise community contributions to build a culture of giving and gratitude.",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "GPL-3.0-or-later",
   "description": "The Praise REST API running on Node/Express, using MongoDB for storage.",
   "type": "commonjs",

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "GPL-3.0-or-later",
   "description": "The Praise Discord bot is the main way for users to interact with the Praise system.",
   "dependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "GPL-3.0-or-later",
   "description": "The Praise dashboard built on React/Recoil/Tailwind CSS.",
   "private": true,

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "GPL-3.0-or-later",
   "description": "The Prasie data is stored in a MongoDb database."
 }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "GPL-3.0-or-later",
   "type": "commonjs",
   "description": "Praise ENV setup scripts.",


### PR DESCRIPTION
### Added

- Admins can replace an actively assigned quantifier with another #432 #503
- Additional test coverage for api
- Freetext filter of quantification list #422
- Quantify multiple items at the same time #499

### Fixed

- Seeder generates periods and praise in the past, not future
- Remove check that was throwing an error when not all quantifiers were assigned praise and `PRAISE_QUANTIFIERS_ASSIGN_ALL` was enabled #492 #498
- Codebase cleanup, documentation and refactor #509

### Upgrade Instructions 

See standard upgrade instructions at: https://givepraise.xyz/docs/setup/upgrade-praise