### PR TITLE
Upgraded server scripts

### DIFF
--- a/database-backup.sh
+++ b/database-backup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export $(grep -v '^#' .env | xargs)
+docker exec -i mongodb-praise /usr/bin/mongodump --authenticationDatabase admin --archive -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD --db praise_db > database-backup-$(date +"%F-%T").archive

--- a/database-restore.sh
+++ b/database-restore.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+if ! test  -f "$1" ; then
+  echo "Could not find database backup"
+  echo "Usage: database-restore.sh filename\n"
+fi
+export $(grep -v '^#' .env | xargs)
+docker compose -f ./docker-compose.production.yml down
+docker volume rm $(docker volume ls -q)
+docker compose -f ./docker-compose.production.yml up mongodb -d --remove-orphans
+docker exec -i mongodb-praise sh -c 'mongorestore --authenticationDatabase admin -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD --nsInclude=praise_db.* --archive' < $1
+docker compose -f ./docker-compose.production.yml up -d --remove-orphans

--- a/reset.sh
+++ b/reset.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+echo
+echo "⚠ Running this script will delete ALL Praise data!"  
+read -p "Are you sure? (N/y) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  echo
+  echo "Shutting down containers..."
+  echo
+  docker compose -f ./docker-compose.production.yml down
+  echo
+  echo "Deleting images..."
+  echo
+  docker rmi -f $(docker images -aq)
+  echo
+  echo "Deleting volumes..."
+  echo
+  docker volume rm $(docker volume ls -q)
+fi

--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker compose -f ./docker-compose.production.yml down
+docker compose -f ./docker-compose.production.yml up

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,9 @@
-docker build -t praise-setup -f ./packages/setup/Dockerfile .
+#!/bin/bash
+IMAGE=$( docker images | grep praise-setup )
+if [ -z "$IMAGE" ]
+then
+  echo "Building setup image..."
+  docker build -t praise-setup -q -f ./packages/setup/Dockerfile .
+fi
+
 docker run -it -v $(pwd):/usr/praise praise-setup

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 docker compose -f ./docker-compose.production.yml up -d

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 docker compose -f ./docker-compose.production.yml pull
 docker compose -f ./docker-compose.production.yml down
 docker compose -f ./docker-compose.production.yml up -d --remove-orphans


### PR DESCRIPTION
Runs scripts using `bash [scriptname]`.

## `setup.sh`

Builds and runs the Praise setup script. Run this script before starting Praise the first time.

## `start.sh`

Starts all Praise services.

## `restart.sh`

Restarts all Praise services. Run this command after changing the server settings.

## `upgrade.sh`

Downloads new server images and restarts Praise to perform the upgrade.

## `database-backup.sh`

Makes a full backup of the database. Backup is saved as a file in the current folder. Script uses login information in `.env`.

## `database-restore.sh`

Usage: `database-restore.sh [filename]`

Deletes the currently active database and replaces it with data from the backup.

## `reset.sh`

Shuts down all running Praise services, deletes all containers and images. Use with caution. N.b. The server setting are not reset, all database passwords etc are left untouched.



