### PR TITLE
Fix: Period validation rules enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactored some of the UI componentsb #537 #482
 - Allow header banner messages to be closed #528 #541
+- Re-introduces the enforcement of validation rules when creating periods. New periods must be created at least 7 days after the previous/latest period. #518 #550
 
 ## [0.10.0] - 2022-07-01
 

--- a/packages/api/src/period/controllers/core.ts
+++ b/packages/api/src/period/controllers/core.ts
@@ -2,7 +2,7 @@ import { Types } from 'mongoose';
 import { StatusCodes } from 'http-status-codes';
 import { Request, Response } from 'express';
 import { Parser } from 'json2csv';
-import { parseISO } from 'date-fns';
+import { add, compareAsc, parseISO } from 'date-fns';
 import { BadRequestError, NotFoundError } from '@/error/errors';
 import { PraiseDtoExtended, PraiseDetailsDto, PraiseDto } from '@/praise/types';
 import {
@@ -110,12 +110,24 @@ export const create = async (
   req: TypedRequestBody<PeriodUpdateInput>,
   res: TypedResponse<PeriodDetailsDto>
 ): Promise<void> => {
-  const { name, endDate } = req.body;
+  const { name, endDate: endDateInput } = req.body;
 
-  if (!name || !endDate)
+  if (!name || !endDateInput)
     throw new BadRequestError('Period name and endDate are required');
 
-  const period = await PeriodModel.create({ name, endDate: parseISO(endDate) });
+  const endDate = parseISO(endDateInput);
+
+  const latestPeriod = await PeriodModel.getLatest();
+  if (latestPeriod) {
+    const earliestDate = add(latestPeriod.endDate, { days: 7 });
+    if (compareAsc(earliestDate, endDate) === 1) {
+      throw new BadRequestError(
+        'End date must be at least 7 days after the latest end date'
+      );
+    }
+  }
+
+  const period = await PeriodModel.create({ name, endDate });
   await insertNewPeriodSettings(period);
 
   await logEvent(
@@ -167,7 +179,7 @@ export const update = async (
   if (endDate) {
     const latest = await isPeriodLatest(period);
     if (!latest)
-      throw new BadRequestError('Date change only allowed on last period.');
+      throw new BadRequestError('Date change only allowed on latest period.');
 
     if (period.status !== PeriodStatusType.OPEN)
       throw new BadRequestError('Date change only allowed on open periods.');

--- a/packages/api/src/period/entities.ts
+++ b/packages/api/src/period/entities.ts
@@ -1,9 +1,13 @@
 import { Schema, model } from 'mongoose';
-import { mongoosePagination, Pagination } from 'mongoose-paginate-ts';
-import { PeriodDocument, PeriodStatusType } from '@/period/types';
+import { mongoosePagination } from 'mongoose-paginate-ts';
+import {
+  PaginatedPeriodModel,
+  PeriodDocument,
+  PeriodStatusType,
+} from '@/period/types';
 import { endDateValidators } from './validators';
 
-const periodSchema = new Schema<PeriodDocument>(
+const PeriodSchema = new Schema<PeriodDocument>(
   {
     name: { type: String, required: true, minlength: 3, maxlength: 64 },
     status: {
@@ -22,11 +26,13 @@ const periodSchema = new Schema<PeriodDocument>(
   }
 );
 
-periodSchema.plugin(mongoosePagination);
+PeriodSchema.statics.getLatest = function (): PeriodDocument {
+  return this.findOne({}).sort({ endDate: -1 });
+};
 
-const PeriodModel = model<PeriodDocument, Pagination<PeriodDocument>>(
+PeriodSchema.plugin(mongoosePagination);
+
+export const PeriodModel = model<PeriodDocument, PaginatedPeriodModel>(
   'Period',
-  periodSchema
+  PeriodSchema
 );
-
-export { PeriodModel };

--- a/packages/api/src/period/types.ts
+++ b/packages/api/src/period/types.ts
@@ -1,4 +1,5 @@
-import { Document, Types } from 'mongoose';
+import { Document, Model, Types } from 'mongoose';
+import { PaginationModel, PaginationOptions } from 'mongoose-paginate-ts';
 import {
   Quantifier,
   QuantificationDocument,
@@ -27,6 +28,14 @@ interface Period {
 export interface PeriodDocument extends Period, Document {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   $__: any;
+}
+
+export interface PaginatedPeriodModel extends Model<PeriodDocument> {
+  getLatest: () => Promise<PeriodDocument>;
+  paginate(
+    options?: PaginationOptions | undefined,
+    onError?: Function | undefined
+  ): Promise<PaginationModel<PeriodDocument> | undefined>;
 }
 
 export interface PeriodDetailsReceiver {

--- a/packages/api/src/tests/period.core.spec.ts
+++ b/packages/api/src/tests/period.core.spec.ts
@@ -1,7 +1,7 @@
 import { Wallet } from 'ethers';
 import { expect } from 'chai';
 import { faker } from '@faker-js/faker';
-import { addDays } from 'date-fns';
+import { add, addDays } from 'date-fns';
 import { PraiseModel } from '@/praise/entities';
 import { PeriodModel } from '@/period/entities';
 import {
@@ -483,6 +483,72 @@ describe('POST /api/admin/periods/create', () => {
       .set('Accept', 'application/json')
       .send(FORM_DATA)
       .expect(401);
+  });
+
+  it('400 response if creating period less than 7 days after previous', async function () {
+    const wallet = Wallet.createRandom();
+    await seedUser({
+      ethereumAddress: wallet.address,
+      roles: ['USER', 'ADMIN'],
+    });
+    const { accessToken } = await loginUser(wallet, this.client);
+
+    const FORM_DATA = {
+      name: faker.animal.type(),
+      endDate: '2022-08-01T00:00:00.000Z',
+    };
+
+    await this.client
+      .post('/api/admin/periods/create')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('Accept', 'application/json')
+      .send(FORM_DATA);
+
+    const FORM_DATA2 = {
+      name: faker.animal.type(),
+      endDate: '2022-08-04T00:00:00.000Z',
+    };
+
+    return this.client
+      .post('/api/admin/periods/create')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('Accept', 'application/json')
+      .send(FORM_DATA2)
+      .expect('Content-Type', /json/)
+      .expect(400);
+  });
+
+  it('200 response if creating period more than 7 days after previous', async function () {
+    const wallet = Wallet.createRandom();
+    await seedUser({
+      ethereumAddress: wallet.address,
+      roles: ['USER', 'ADMIN'],
+    });
+    const { accessToken } = await loginUser(wallet, this.client);
+
+    const FORM_DATA = {
+      name: faker.animal.type(),
+      endDate: '2022-08-01T00:00:00.000Z',
+    };
+
+    await this.client
+      .post('/api/admin/periods/create')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('Accept', 'application/json')
+      .send(FORM_DATA);
+
+    const FORM_DATA2 = {
+      name: faker.animal.type(),
+      endDate: '2022-08-09T00:00:00.000Z',
+    };
+
+    return this.client
+      .post('/api/admin/periods/create')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('Accept', 'application/json')
+      .send(FORM_DATA2)
+      .expect('Content-Type', /json/)
+      .expect(200);
   });
 });
 

--- a/packages/frontend/src/pages/Periods/PeriodsPage.tsx
+++ b/packages/frontend/src/pages/Periods/PeriodsPage.tsx
@@ -2,21 +2,15 @@ import { faCalendarAlt, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
 import { ActiveNoticesBoard } from '@/components/periods/ActiveNoticesBoard';
 import { BreadCrumb } from '@/components/ui/BreadCrumb';
 import { AdminOnly } from '@/components/auth/AdminOnly';
-import { AllPeriods } from '@/model/periods';
 import { Page } from '@/components/ui/Page';
 import { Button } from '@/components/ui/Button';
 import { Box } from '@/components/ui/Box';
 import { PeriodsTable } from './components/Table';
 
 const PeriodsPage = (): JSX.Element | null => {
-  const allPeriods = useRecoilValue(AllPeriods);
-
-  if (!allPeriods) return null;
-
   return (
     <Page>
       <BreadCrumb name="Quantification periods" icon={faCalendarAlt} />


### PR DESCRIPTION
Resolves #518. Re-introduces the enforcement of validation rules when creating periods. New periods must be created at least 7 days after the previous/latest period.
 

