### PR TITLE
Fix QuantifySlider dark/light mode

### DIFF
--- a/packages/frontend/src/components/form/BooleanInput.tsx
+++ b/packages/frontend/src/components/form/BooleanInput.tsx
@@ -4,14 +4,15 @@ import { FieldErrorMessage } from '@/components/form/FieldErrorMessage';
 
 export const BooleanInput = (
   name: string,
-  apiResponse: AxiosResponse<unknown> | AxiosError | null
+  apiResponse: AxiosResponse<unknown> | AxiosError | null,
+  disabled?: boolean
 ): JSX.Element => {
   return (
     <Field name={name} key={name} type="checkbox">
       {({ input }): JSX.Element => {
         return (
           <div>
-            <input id={name} {...input} />
+            <input id={name} {...input} disabled={disabled || false} />
             {apiResponse && (
               <FieldErrorMessage name="name" apiResponse={apiResponse} />
             )}

--- a/packages/frontend/src/components/form/ImageFileInput.tsx
+++ b/packages/frontend/src/components/form/ImageFileInput.tsx
@@ -2,7 +2,8 @@ import { Field } from 'react-final-form';
 
 export const ImageFileInput = (
   name: string,
-  src: string | undefined
+  src: string | undefined,
+  disabled?: boolean
 ): JSX.Element => {
   return (
     <Field<FileList> name={name} key={name}>
@@ -15,6 +16,7 @@ export const ImageFileInput = (
             type="file"
             className="block w-full"
             onChange={({ target }): void => onChange(target.files)}
+            disabled={disabled || false}
           />
 
           <div className="mt-2">

--- a/packages/frontend/src/components/form/NumberInput.tsx
+++ b/packages/frontend/src/components/form/NumberInput.tsx
@@ -4,7 +4,8 @@ import { FieldErrorMessage } from '@/components/form/FieldErrorMessage';
 
 export const NumberInput = (
   name: string,
-  apiResponse: AxiosResponse<unknown> | AxiosError | null
+  apiResponse: AxiosResponse<unknown> | AxiosError | null,
+  disabled?: boolean
 ): JSX.Element => {
   return (
     <Field name={name} key={name}>
@@ -16,6 +17,7 @@ export const NumberInput = (
             {...input}
             autoComplete="off"
             className="block w-full"
+            disabled={disabled || false}
           />
           {apiResponse && (
             <FieldErrorMessage name="name" apiResponse={apiResponse} />

--- a/packages/frontend/src/components/form/StringInput.tsx
+++ b/packages/frontend/src/components/form/StringInput.tsx
@@ -4,7 +4,8 @@ import { FieldErrorMessage } from '@/components/form/FieldErrorMessage';
 
 export const StringInput = (
   name: string,
-  apiResponse: AxiosResponse<unknown> | AxiosError | null
+  apiResponse: AxiosResponse<unknown> | AxiosError | null,
+  disabled?: boolean
 ): JSX.Element => {
   return (
     <Field name={name} key={name}>
@@ -17,6 +18,7 @@ export const StringInput = (
               {...input}
               autoComplete="off"
               className="block w-full"
+              disabled={disabled || false}
             />
             {apiResponse && (
               <FieldErrorMessage name="name" apiResponse={apiResponse} />

--- a/packages/frontend/src/components/form/TextareaInput.tsx
+++ b/packages/frontend/src/components/form/TextareaInput.tsx
@@ -4,7 +4,8 @@ import { FieldErrorMessage } from '@/components/form/FieldErrorMessage';
 
 export const TextareaInput = (
   name: string,
-  apiResponse: AxiosResponse<unknown> | AxiosError | null
+  apiResponse: AxiosResponse<unknown> | AxiosError | null,
+  disabled?: boolean
 ): JSX.Element => {
   return (
     <Field name={name} key={name}>
@@ -17,6 +18,7 @@ export const TextareaInput = (
             autoComplete="off"
             className="block w-full resize-y"
             rows={4}
+            disabled={disabled || false}
           />
           {apiResponse && (
             <FieldErrorMessage name="name" apiResponse={apiResponse} />

--- a/packages/frontend/src/components/settings/SettingsForm.tsx
+++ b/packages/frontend/src/components/settings/SettingsForm.tsx
@@ -27,7 +27,8 @@ interface SettingsFormProps {
 
 const FormFields = (
   settings: SettingDto[] | PeriodSettingDto[],
-  apiResponse
+  apiResponse,
+  disabled?: boolean
 ): JSX.Element => {
   return (
     <div className="mb-2 space-y-4">
@@ -38,18 +39,22 @@ const FormFields = (
           setting.type === 'IntegerList' ||
           setting.type === 'StringList'
         )
-          field = StringInput(setting.key, apiResponse);
+          field = StringInput(setting.key, apiResponse, disabled);
         else if (setting.type === 'Float' || setting.type === 'Integer')
-          field = NumberInput(setting.key, apiResponse);
+          field = NumberInput(setting.key, apiResponse, disabled);
         else if (
           setting.type === 'Textarea' ||
           setting.type === 'QuestionAnswerJSON'
         )
-          field = TextareaInput(setting.key, apiResponse);
+          field = TextareaInput(setting.key, apiResponse, disabled);
         else if (setting.type === 'Boolean')
-          field = BooleanInput(setting.key, apiResponse);
+          field = BooleanInput(setting.key, apiResponse, disabled);
         else if (setting.type === 'Image')
-          field = ImageFileInput(setting.key, setting.valueRealized as string);
+          field = ImageFileInput(
+            setting.key,
+            setting.valueRealized as string,
+            disabled
+          );
 
         if (!field) return null;
 
@@ -68,29 +73,6 @@ const FormFields = (
     </div>
   );
 };
-
-const DisabledFormFields = (
-  settings: SettingDto[] | PeriodSettingDto[]
-): JSX.Element => (
-  <>
-    <Notice type="info" className="mb-8">
-      <span>Settings locked for this period</span>
-    </Notice>
-    <div className="mb-2 space-y-4">
-      {settings.map((setting: SettingDto | PeriodSettingDto) => (
-        <div key={setting.key}>
-          <label className="block font-bold">{setting.label}</label>
-          {setting.description && (
-            <div className="mb-2 text-sm text-warm-gray-400">
-              {setting.description}
-            </div>
-          )}
-          <div className="p-2 bg-warm-gray-200">{setting.value}</div>
-        </div>
-      ))}
-    </div>
-  </>
-);
 
 export const SettingsForm = ({
   settings,
@@ -146,19 +128,29 @@ export const SettingsForm = ({
         },
       }}
       render={({ handleSubmit }): JSX.Element => {
-        if (disabled) {
-          return DisabledFormFields(settings);
-        } else {
-          return (
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            <form onSubmit={handleSubmit} className="leading-loose">
-              {FormFields(settings, apiResponse)}
+        return (
+          <>
+            {disabled && (
+              <Notice type="info" className="mb-8">
+                <span>
+                  The settings cannot be changed once a period is in
+                  quantification.
+                </span>
+              </Notice>
+            )}
+            <form
+              onSubmit={(): void => {
+                void handleSubmit();
+              }}
+              className="leading-loose"
+            >
+              {FormFields(settings, apiResponse, disabled)}
               <div className="mt-4">
                 <SubmitButton />
               </div>
             </form>
-          );
-        }
+          </>
+        );
       }}
     />
   );

--- a/packages/frontend/src/navigation/Nav.tsx
+++ b/packages/frontend/src/navigation/Nav.tsx
@@ -73,13 +73,13 @@ export const Nav = (): JSX.Element => {
 
         <div className="flex h-12 m-4 mt-auto">
           <div
-            className="items-center justify-center hidden border-2 rounded-lg cursor-pointer dark:flex dark:text-white text-themecolor-3 grow dark:border-slate-700"
+            className="items-center justify-center hidden h-12 border-2 rounded-lg cursor-pointer dark:flex dark:text-white text-themecolor-3 grow dark:border-slate-700"
             onClick={(): void => handleTheme('Light')}
           >
             <FontAwesomeIcon icon={faSun} size="lg" />
           </div>
           <div
-            className="flex items-center justify-center border-2 rounded-lg cursor-pointer dark:hidden dark:text-white text-themecolor-3 grow dark:border-slate-700"
+            className="flex items-center justify-center h-12 border-2 rounded-lg cursor-pointer dark:hidden dark:text-white text-themecolor-3 grow dark:border-slate-700"
             onClick={(): void => handleTheme('Dark')}
           >
             <FontAwesomeIcon icon={faMoon} size="lg" />

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/DuplicateDialog.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/DuplicateDialog.tsx
@@ -83,7 +83,7 @@ export const DuplicateDialog = ({
           )}
           <Praise
             praise={originalPraise}
-            className="p-5 rounded-md bg-warm-gray-100"
+            className="p-5 rounded-md bg-warm-gray-100 dark:bg-slate-500"
             showScore={false}
             bigGiverAvatar={false}
             showReceiver={false}

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifySlider.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifySlider.tsx
@@ -1,5 +1,31 @@
 import { Slider, Tooltip } from '@mui/material';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import React, { useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { Theme } from '@/model/theme';
+
+// Define two themes for @mui slider: light & dark theme
+const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    ...{
+      primary: {
+        main: '#334155',
+      },
+    },
+  },
+});
+
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    ...{
+      primary: {
+        main: '#ffffff',
+      },
+    },
+  },
+});
 
 interface ValueLabelComponentProps {
   children: JSX.Element;
@@ -46,6 +72,9 @@ export const QuantifySlider = ({
   score = 0,
   onChange,
 }: QuantifySliderProps): JSX.Element => {
+  // Get theme style data for @mui slider
+  const theme = useRecoilValue(Theme);
+
   // Mark that is *visually* selected in the UI
   const [selectedMark, setSelectedMark] = useState<Mark>(defaultMark);
   const [marks, setMarks] = useState<Mark[]>([]);
@@ -106,23 +135,21 @@ export const QuantifySlider = ({
 
   return (
     <div className="inline-block w-40">
-      <Slider
-        classes={{
-          colorPrimary: 'local-MuiSlider-colorPrimary',
-          disabled: 'local-MuiSlider-disabled',
-        }}
-        valueLabelDisplay="on"
-        step={null}
-        components={{ ValueLabel: ValueLabelComponent }}
-        marks={marks}
-        valueLabelFormat={valueLabelFormat}
-        value={selectedMark.value}
-        disabled={disabled}
-        onChange={handleOnChange}
-        onChangeCommitted={handleOnChangeCommitted}
-        min={0}
-        max={maxMarkValue()}
-      />
+      <ThemeProvider theme={theme === 'Dark' ? darkTheme : lightTheme}>
+        <Slider
+          valueLabelDisplay="on"
+          step={null}
+          components={{ ValueLabel: ValueLabelComponent }}
+          marks={marks}
+          valueLabelFormat={valueLabelFormat}
+          value={selectedMark.value}
+          disabled={disabled}
+          onChange={handleOnChange}
+          onChangeCommitted={handleOnChangeCommitted}
+          min={0}
+          max={maxMarkValue()}
+        />
+      </ThemeProvider>
     </div>
   );
 };

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/components/QuantifyTable.tsx
@@ -219,7 +219,10 @@ export const QuantifyTable = ({
         </div>
       </div>
 
-      <Box className="p-0 pb-5 overflow-x-auto rounded-t-none" variant={'wide'}>
+      <Box
+        className="p-0 pb-5 overflow-x-auto !rounded-t-none"
+        variant={'wide'}
+      >
         <table className="w-full table-auto">
           <tbody>
             {Object.keys(weeklyData).map((weekKey, index) => (

--- a/packages/frontend/src/styles/custom-components.css
+++ b/packages/frontend/src/styles/custom-components.css
@@ -1,8 +1,0 @@
-/* MUI Slider styles */
-.local-MuiSlider-colorPrimary {
-  @apply !text-warm-gray-800;
-}
-
-.local-MuiSlider-disabled {
-  @apply text-warm-gray-400;
-}

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -22,32 +22,30 @@
     @apply underline;
   }
 
-  input, textarea {
-    @apply text-sm dark:border-slate-400 dark:bg-slate-500 dark:placeholder-white; 
+  input,
+  textarea {
+    @apply text-sm dark:border-slate-400 dark:bg-slate-500 dark:placeholder-white dark:disabled:text-slate-400 dark:disabled:border-slate-400 disabled:text-warm-gray-400 disabled:border-warm-gray-400;
   }
-
 
   [type='text']:focus,
-    [type='email']:focus,
-    [type='url']:focus,
-    [type='password']:focus,
-    [type='number']:focus,
-    [type='date']:focus,
-    [type='datetime-local']:focus,
-    [type='month']:focus,
-    [type='search']:focus,
-    [type='tel']:focus,
-    [type='time']:focus,
-    [type='week']:focus,
-    [multiple]:focus,
-    textarea:focus,
-    select:focus {
-      @apply  border-warm-gray-900 dark:border-slate-300 dark:focus:ring-slate-300 focus:ring-warm-gray-900;
-    }
-    
-    [type='checkbox'] {
-      @apply text-gray-900 border border-warm-gray-900 focus:border-warm-gray-900 focus:border-2 focus:ring-0;
-    }
-    
+  [type='email']:focus,
+  [type='url']:focus,
+  [type='password']:focus,
+  [type='number']:focus,
+  [type='date']:focus,
+  [type='datetime-local']:focus,
+  [type='month']:focus,
+  [type='search']:focus,
+  [type='tel']:focus,
+  [type='time']:focus,
+  [type='week']:focus,
+  [multiple]:focus,
+  textarea:focus,
+  select:focus {
+    @apply border-warm-gray-900 dark:border-slate-300 dark:focus:ring-slate-300 focus:ring-warm-gray-900;
   }
 
+  [type='checkbox'] {
+    @apply text-gray-900 border border-warm-gray-900 focus:border-warm-gray-900 focus:border-2 focus:ring-0;
+  }
+}


### PR DESCRIPTION
Removed classes directly attached to the Slicer component, added two theme definitions for @mui themes: dark & light. Included theme variable from recoil

Resolves #488 