### PR TITLE
Fix env error

### DIFF
--- a/packages/frontend/.env.template
+++ b/packages/frontend/.env.template
@@ -13,7 +13,3 @@ PORT=3000
 
 # App version from package.json
 REACT_APP_VERSION=$npm_package_version
-
-# Github repo info
-REACT_APP_GITHUB_REPO_OWNER=commons-stack
-REACT_APP_GITHUB_REPO_NAME=praise

--- a/packages/frontend/src/model/app.ts
+++ b/packages/frontend/src/model/app.ts
@@ -13,8 +13,8 @@ export interface GithubResponse {
 export const GithubVersionQuery = selector({
   key: 'GithubVersionQuery',
   get: ({ get }): AxiosResponse<GithubResponse> => {
-    const repoOwner = process.env.REACT_APP_GITHUB_REPO_OWNER;
-    const repoName = process.env.REACT_APP_GITHUB_REPO_NAME;
+    const repoOwner = 'commons-stack';
+    const repoName = 'praise';
 
     return get(
       ExternalGet({


### PR DESCRIPTION
Fixes a bug that prevented the praise dashboard from running in production. Frontend runtime settings cannot be included in .ENV since Praise runs on a prebuilt image in production.