### PR TITLE
Fix/evenly assign quantifiers prevent overlap

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,5 +10,15 @@ docker exec -i mongodb-praise /usr/bin/mongodump --authenticationDatabase admin 
 
 **Restore**
 ```
-docker exec -i mongodb-praise sh -c 'mongorestore --authenticationDatabase admin -u DB_ROOT_USER -p DB_ROOT_PASSWORD --db praise_db --archive' < database-backup-BACKUP_DATE.archive
+docker exec -i mongodb-praise sh -c "mongorestore --authenticationDatabase admin -u DB_ROOT_USER -p DB_ROOT_PASSWORD --db praise_db --archive" < database-backup-BACKUP_DATE.archive
+```
+
+### Connect to mongodb database running on docker
+```
+docker exec -it mongodb-praise sh -c "mongosh  \"mongodb://DB_USER:DB_PASSWORD@127.0.0.1:27017/DB_NAME\""
+```
+
+### Run Api Tests
+```
+docker exec -it api-praise yarn workspace api test
 ```

--- a/packages/api/src/period/utils/assignment.ts
+++ b/packages/api/src/period/utils/assignment.ts
@@ -221,6 +221,20 @@ const verifyAssignments = async (
       `Not all redundant praise assignments accounted for: ${accountedPraiseCount} / ${expectedAccountedPraiseCount} expected in period`
     );
   }
+
+  const verifiedUniqueAssignments = assignments.poolAssignments.map(
+    (quantifier) =>
+      quantifier.receivers.length ===
+      new Set(quantifier.receivers.map((r) => r._id.toString())).size
+  );
+
+  if (every(verifiedUniqueAssignments)) {
+    logger.info('All redundant praise are assigned to unique quantifiers');
+  } else {
+    throw new InternalServerError(
+      'Some redundant praise are assigned to the same quantifier multiple times'
+    );
+  }
 };
 
 /**

--- a/packages/api/src/tests/period.assignment.spec.ts
+++ b/packages/api/src/tests/period.assignment.spec.ts
@@ -2,6 +2,7 @@ import { Wallet } from 'ethers';
 import { expect } from 'chai';
 import { faker } from '@faker-js/faker';
 import some from 'lodash/some';
+import sum from 'lodash/sum';
 import {
   seedPeriod,
   seedPraise,
@@ -14,6 +15,7 @@ import { PraiseModel } from '@/praise/entities';
 import { PeriodSettingsModel } from '@/periodsettings/entities';
 import { UserModel } from '@/user/entities';
 import { UserAccountModel } from '@/useraccount/entities';
+import { PeriodDetailsQuantifierDto } from '@/period/types';
 import { loginUser } from './utils';
 
 describe('PATCH /api/admin/periods/:periodId/assignQuantifiers', () => {
@@ -244,6 +246,9 @@ describe('PATCH /api/admin/periods/:periodId/assignQuantifiers', () => {
     await seedUser({
       roles: ['USER', 'QUANTIFIER'],
     });
+    await seedUser({
+      roles: ['USER', 'QUANTIFIER'],
+    });
 
     const response = await this.client
       .patch(
@@ -275,10 +280,14 @@ describe('PATCH /api/admin/periods/:periodId/assignQuantifiers', () => {
     );
     expect(response.body.receivers[2].praiseCount).to.equal(3);
 
-    expect(response.body.quantifiers).to.have.length(3);
-    expect(response.body.quantifiers[0].praiseCount).to.equal(12);
-    expect(response.body.quantifiers[1].praiseCount).to.equal(12);
-    expect(response.body.quantifiers[2].praiseCount).to.equal(12);
+    expect(response.body.quantifiers).to.have.length(5);
+    expect(
+      sum(
+        response.body.quantifiers.map(
+          (q: PeriodDetailsQuantifierDto) => q.praiseCount
+        )
+      )
+    ).to.equal(12 * 3);
 
     expect(response.body.quantifiers[0].finishedCount).to.equal(0);
     expect(response.body.quantifiers[1].finishedCount).to.equal(0);

--- a/packages/frontend/src/model/periods.ts
+++ b/packages/frontend/src/model/periods.ts
@@ -26,7 +26,7 @@ import {
   periodReceiverPraiseListKey,
 } from '@/utils/periods';
 import { useApiAuthClient } from '@/utils/api';
-import { ApiAuthGet, isResponseOk } from './api';
+import { ApiAuthGet, isApiResponseAxiosError, isResponseOk } from './api';
 import { ActiveUserId } from './auth';
 import { AllPraiseList, PraiseIdList, SinglePraise } from './praise';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -353,6 +353,10 @@ export const useAssignQuantifiers = (
         status: 'QUANTIFY' as PeriodStatusType,
       };
       setPeriod(updatedPeriod);
+      return response as AxiosResponse<PeriodDetailsDto>;
+    }
+    if (isApiResponseAxiosError(response)) {
+      throw response;
     }
     return response as AxiosResponse | AxiosError;
   };

--- a/packages/frontend/src/pages/Periods/Details/components/PeriodDetails.tsx
+++ b/packages/frontend/src/pages/Periods/Details/components/PeriodDetails.tsx
@@ -58,22 +58,29 @@ export const PeriodDetails = (): JSX.Element | null => {
   };
 
   const handleAssign = (): void => {
+    const toastId = 'assignToast';
     const promise = assignQuantifiers();
     void toast.promise(
       promise,
       {
         loading: 'Assigning quantifiers …',
-        success: 'Quantifiers assigned',
-        error: 'Assign failed',
+        success: () => {
+          setTimeout(() => history.go(0), 2000);
+          return 'Quantifiers assigned';
+        },
+        error: () => {
+          setTimeout(() => toast.remove(toastId), 2000);
+          return 'Assign failed';
+        },
       },
       {
+        id: toastId,
         position: 'top-center',
         loading: {
           duration: Infinity,
         },
       }
     );
-    promise.finally(() => setTimeout(() => history.go(0), 1000));
   };
 
   const handleExport = (): void => {

--- a/packages/frontend/src/utils/axios.ts
+++ b/packages/frontend/src/utils/axios.ts
@@ -6,7 +6,7 @@ import { toast } from 'react-hot-toast';
  *
  * @param err
  */
-export const handleErrors = (err: AxiosError): void => {
+export const handleErrors = (err: AxiosError): AxiosError => {
   // Any HTTP Code which is not 2xx will be considered as error
   const statusCode = err?.response?.status;
 
@@ -25,6 +25,7 @@ export const handleErrors = (err: AxiosError): void => {
   } else {
     toast.error('Unknown Error');
   }
+  return err;
 };
 
 /**


### PR DESCRIPTION
Resolves #535

- Verify that no quantifier has been assigned to same receiver multiple times, before generating assignments
- Refactor `prepareAssignmentsEvenly` to prevent a case where a quantifier could be assigned to the same receiver twice
- Improve doc comments explaining `prepareAssignmentsEvenly`

**Post-Mortem**
Previously in `prepareAssignmentsEvenly` we:

1. Generated a list of unique groups of receivers, duplicating each receiver for redundant assignments
2. Attempted to evenly distribute the groups of receivers among all quantifiers, based on the total number of praise in the group of receivers (i.e. a quantifier could be assigned to multiple groups of receivers).

This allowed a case where a quantifier could be assigned a duplicate receivers, because multiple groups of unique receivers could potential contain a duplicate between them.

With this refactor, we swapped the order of these steps. Now we:
1. Attempt to evenly distribute receivers among all quantifiers, based on the total amount of praise each receiver has (i.e. a quantifier could be assigned multiple receivers).
2. Duplicating the assignments, rotating the order, for each redundant quantification.
