### PR TITLE
v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.12.1] - 2022-09-27
+
+A minor release to fix some bugs related to image uploading.
+
+### Fixed
+
 - Better handling of uploaded logo images. Image uploads are now stored outside of the Docker container. This means that the logo image will persist across container restarts and upgrades. #564 #604
 - Better support for serving Praise over http on localhost. No manual edits of `.env` needed, all settings are managed by `setup.sh`. #577 #604
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praise",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "GPL-3.0-or-later",
   "description": "Praise community contributions to build a culture of giving and gratitude.",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "GPL-3.0-or-later",
   "description": "The Praise REST API running on Node/Express, using MongoDB for storage.",
   "type": "commonjs",

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "GPL-3.0-or-later",
   "description": "The Praise Discord bot is the main way for users to interact with the Praise system.",
   "dependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "GPL-3.0-or-later",
   "description": "The Praise dashboard built on React/Recoil/Tailwind CSS.",
   "private": true,

--- a/packages/frontend/src/model/app.ts
+++ b/packages/frontend/src/model/app.ts
@@ -33,7 +33,7 @@ interface PraiseAppVersion {
 
 export const usePraiseAppVersion = (): PraiseAppVersion => {
   const appVersion: PraiseAppVersion = {
-    current: '0.12.0', //TODO: get this from package.json
+    current: '0.12.1', //TODO: get this from package.json
     latest: undefined,
     newVersionAvailable: false,
   };

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "GPL-3.0-or-later",
   "description": "The Prasie data is stored in a MongoDb database."
 }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "GPL-3.0-or-later",
   "type": "commonjs",
   "description": "Praise ENV setup scripts.",


### PR DESCRIPTION
A minor release to fix some bugs related to image uploading.

### Fixed

- Better handling of uploaded logo images. Image uploads are now stored outside of the Docker container. This means that the logo image will persist across container restarts and upgrades. #564 #604
- Better support for serving Praise over http on localhost. No manual edits of `.env` needed, all settings are managed by `setup.sh`. #577 #604
