### PR TITLE
v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API:** Quantify endpoint now disallows any scores that are not in the configured range #608 #610
 - **Frontend:** Praise logo in dashboard is now linked again, taking user to start page #609 #611
 
+### Upgrade Instructions
+
+Beacause of changes to the `.env` file structure, you need to run the setup script after pulling
+changes from GitHub.
+
+1. `git pull`
+2. `bash setup.sh`
+3. `bash upgrade.sh`
+
 ## [0.12.1] - 2022-09-27
 
 A minor release to fix some bugs related to image uploading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Setup script now uses a prebuilt Docker image to speed up setup process. #575 #606
+## [0.12.2] - 2022-09-28
+
+### Added
+
+- **Devops:** Setup script now uses a prebuilt Docker image to speed up setup process. #575 #606
+- **Devops:** Merged project `.env` files into a single root file to simplify for automated setup #591
+
+### Fixed
+
+- **API:** Quantify endpoint now disallows any scores that are not in the configured range #608 #610
+- **Frontend:** Praise logo in dashboard is now linked again, taking user to start page #609 #611
 
 ## [0.12.1] - 2022-09-27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praise",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "GPL-3.0-or-later",
   "description": "Praise community contributions to build a culture of giving and gratitude.",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "GPL-3.0-or-later",
   "description": "The Praise REST API running on Node/Express, using MongoDB for storage.",
   "type": "commonjs",

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "GPL-3.0-or-later",
   "description": "The Praise Discord bot is the main way for users to interact with the Praise system.",
   "dependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "GPL-3.0-or-later",
   "description": "The Praise dashboard built on React/Recoil/Tailwind CSS.",
   "private": true,

--- a/packages/frontend/src/model/app.ts
+++ b/packages/frontend/src/model/app.ts
@@ -33,7 +33,7 @@ interface PraiseAppVersion {
 
 export const usePraiseAppVersion = (): PraiseAppVersion => {
   const appVersion: PraiseAppVersion = {
-    current: '0.12.1', //TODO: get this from package.json
+    current: '0.12.2', //TODO: get this from package.json
     latest: undefined,
     newVersionAvailable: false,
   };

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "GPL-3.0-or-later",
   "description": "The Prasie data is stored in a MongoDb database."
 }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "GPL-3.0-or-later",
   "type": "commonjs",
   "description": "Praise ENV setup scripts.",


### PR DESCRIPTION
### Added

- **Devops:** Setup script now uses a prebuilt Docker image to speed up setup process. #575 #606
- **Devops:** Merged project `.env` files into a single root file to simplify for automated setup #591

### Fixed

- **API:** Quantify endpoint now disallows any scores that are not in the configured range #608 #610
- **Frontend:** Praise logo in dashboard is now linked again, taking user to start page #609 #611

### Upgrade Instructions

Beacause of changes to the `.env` file structure, you need to run the setup script after pulling
changes from GitHub.

1. `git pull`
2. `bash setup.sh`
3. `bash upgrade.sh`